### PR TITLE
Update DBM_Core.lua

### DIFF
--- a/JH_DBM/DBM_Core.lua
+++ b/JH_DBM/DBM_Core.lua
@@ -561,7 +561,9 @@ function D.CountdownEvent(data, nClass)
 		local i = 1
 		for k, v in ipairs(data.tCountdown) do
 			if nClass == v.nClass then
-				if i > 2 then
+				if v.nTime == 0 then
+					i = i + 1
+				elseif i > 2 then
 					break;
 				end
 				i = i + 1


### PR DESCRIPTION
时间为0的倒计时主要用于避免多段倒计时在转阶段或异常脱离等情况时能够控制倒计时不会发生错乱。并不影响游戏画面，建议时间为0的倒计时不计算到2个触发倒计时的总量上。