### PR TITLE
Create DBM_Core.lua

### DIFF
--- a/JH_DBM/DBM_Core.lua
+++ b/JH_DBM/DBM_Core.lua
@@ -561,13 +561,12 @@ function D.CountdownEvent(data, nClass)
 		local i = 1
 		for k, v in ipairs(data.tCountdown) do
 			if nClass == v.nClass then
-				if v.nTime ~= 0 then
-					if i > 2 then
+				if v.nTime ~= 0 and v.nRefresh ~= 0 then
+				    if i > 2 then
 						break
 					else
 						i = i + 1
 					end
-				end
 				local szKey = k .. "." .. (data.dwID or 0) .. "." .. (data.nLevel or 0)
 				local tParam = {
 					key      = v.key,
@@ -580,6 +579,26 @@ function D.CountdownEvent(data, nClass)
 					bHold    = v.bHold
 				}
 				D.FireCountdownEvent(nClass, szKey, tParam)
+					
+				else
+				local szKey = k .. "." .. (data.dwID or 0) .. "." .. (data.nLevel or 0)
+				local tParam = {
+					key      = v.key,
+					nFrame   = v.nFrame,
+					nTime    = v.nTime+0.01,
+					nRefresh = v.nRefresh,
+					szName   = v.szName or data.szName,
+					nIcon    = v.nIcon or data.nIcon,
+					bTalk    = v.bTeamChannel,
+					bHold    = v.bHold
+				}
+				D.FireCountdownEvent(nClass, szKey, tParam)
+					if i > 2 then
+						break
+					else
+						i = i + 1
+					end
+				end
 			end
 		end
 	end


### PR DESCRIPTION
简介：修复ntime为0时，无视Refresh时间直接刷新计时的问题；
变更：修改了局部变量位置，保留计时条限制的同时保证refresh的生效；避免“nn，0，n”对refresh不为0或空的计时进行清空；
附注："nn，0，0；"将受到被刷新计时refresh的影响，但是可以正常清空被刷新计时refresh为0或者空值的计时；
----本部分所有内容基于同一标识（Key）